### PR TITLE
Add Scarlett mixer prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python app.py
 ```
 
 * Desktop UI appears.
-* Phone: connect to `http://<your-linux-ip>:8088/` (same LAN). You’ll see **Mix B** controls + meters.
+* Phone: connect to `http://<your-linux-ip>:8088/` (same LAN). You’ll see **Mix A** controls that stay in sync with the desktop UI.
 
 ## Next steps
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Scarlett Mixer
+# Scarlett Mixer Prototype
+
+Modern Qt/QML desktop mixer with a built-in FastAPI WebSocket server for phone control.
+
+## Install
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -U pip
+pip install -e .
+```
+
+## Run
+
+```bash
+python app.py
+```
+
+* Desktop UI appears.
+* Phone: connect to `http://<your-linux-ip>:8088/` (same LAN). You’ll see **Mix B** controls + meters.
+
+## Next steps
+
+* Wire **ALSA**: in `backend.set_*` routines, resolve the correct ALSA mixer controls and write.
+* Add **MIDI (X-Touch Mini)**: read CC, map to `set_*` methods, send ring LED feedback.
+* Replace **fake meters** with **JACK** peak/RMS, throttle to ~15–30 Hz for web.
+* Add auth and per-mix scoping tokens for band mates.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,75 @@
+import asyncio
+import signal
+
+from PySide6.QtCore import QObject, Slot
+from PySide6.QtGui import QGuiApplication
+from PySide6.QtQml import QQmlApplicationEngine
+import qasync
+import uvicorn
+
+from backend import Backend
+from server import build_api
+
+
+async def _run_uvicorn(app, host: str = "0.0.0.0", port: int = 8088):
+    config = uvicorn.Config(app=app, host=host, port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    await server.serve()
+
+
+class MixBridge(QObject):
+    def __init__(self, backend: Backend):
+        super().__init__()
+        self._backend = backend
+
+    @Slot(str, bool)
+    def setJoin(self, mix: str, joined: bool):
+        asyncio.create_task(self._backend.set_join(mix, joined))
+
+    @Slot(str, float)
+    def setVolume(self, mix: str, value: float):
+        asyncio.create_task(self._backend.set_volume(mix, value))
+
+    @Slot(str, float)
+    def setPan(self, mix: str, value: float):
+        asyncio.create_task(self._backend.set_pan(mix, value))
+
+    @Slot(str, float, float)
+    def setLR(self, mix: str, left: float, right: float):
+        l = None if left < 0 else left
+        r = None if right < 0 else right
+        asyncio.create_task(self._backend.set_lr(mix, l, r))
+
+
+async def _amain():
+    qt_app = QGuiApplication([])
+    engine = QQmlApplicationEngine()
+
+    backend = Backend()
+    api = build_api(backend)
+
+    bridge = MixBridge(backend)
+    engine.rootContext().setContextProperty("bridge", bridge)
+    engine.load("ui/Main.qml")
+    if not engine.rootObjects():
+        raise RuntimeError("Failed to load QML UI")
+
+    asyncio.create_task(backend.meters_task())
+    asyncio.create_task(_run_uvicorn(api))
+
+    loop = asyncio.get_running_loop()
+    stop = asyncio.Event()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop.set)
+
+    await stop.wait()
+    await backend.shutdown()
+
+
+def main_entry():
+    qasync.run(_amain())
+
+
+if __name__ == "__main__":
+    main_entry()

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import asyncio
 import signal
+from pathlib import Path
 
 from PySide6.QtCore import QObject, Slot
 from PySide6.QtGui import QGuiApplication
@@ -42,15 +43,17 @@ class MixBridge(QObject):
 
 
 async def _amain():
+    base_dir = Path(__file__).resolve().parent
+
     qt_app = QGuiApplication([])
     engine = QQmlApplicationEngine()
 
     backend = Backend()
-    api = build_api(backend)
+    api = build_api(backend, base_dir / "web")
 
     bridge = MixBridge(backend)
     engine.rootContext().setContextProperty("bridge", bridge)
-    engine.load("ui/Main.qml")
+    engine.load(str(base_dir / "ui" / "Main.qml"))
     if not engine.rootObjects():
         raise RuntimeError("Failed to load QML UI")
 

--- a/backend.py
+++ b/backend.py
@@ -1,0 +1,129 @@
+import asyncio
+import math
+import time
+from dataclasses import dataclass, asdict
+from typing import Any, Callable, Coroutine, Dict, Optional, Set
+
+
+@dataclass
+class Mix:
+    name: str
+    joined: bool = True
+    volume: float = 0.75
+    pan: float = 0.0
+    gain_l: float = 0.75
+    gain_r: float = 0.75
+    mute: bool = False
+    level_l: float = 0.0
+    level_r: float = 0.0
+
+
+@dataclass
+class AppState:
+    mixes: Dict[str, Mix]
+
+
+class EventBus:
+    def __init__(self):
+        self._subs: Set[Callable[[dict], Coroutine[Any, Any, None]]] = set()
+
+    def subscribe(self, cb: Callable[[dict], Coroutine[Any, Any, None]]):
+        self._subs.add(cb)
+
+    def unsubscribe(self, cb: Callable[[dict], Coroutine[Any, Any, None]]):
+        self._subs.discard(cb)
+
+    async def publish(self, msg: dict):
+        dead: Set[Callable[[dict], Coroutine[Any, Any, None]]] = set()
+        for cb in list(self._subs):
+            try:
+                await cb(msg)
+            except Exception:
+                dead.add(cb)
+        for cb in dead:
+            self._subs.discard(cb)
+
+
+class Backend:
+    """Mixer state holder. Replace TODOs with ALSA/JACK/MIDI integration."""
+
+    def __init__(self):
+        self.state = AppState(
+            mixes={
+                "A": Mix("A"),
+                "B": Mix("B", volume=0.6),
+                "C": Mix("C", volume=0.5),
+            }
+        )
+        self.bus = EventBus()
+        self._stop = asyncio.Event()
+        self._last_broadcast = 0.0
+
+    # --- Helpers ---------------------------------------------------------
+    def _apply_stereo_join(self, mix: Mix):
+        theta = (mix.pan + 1) * math.pi / 4
+        mix.gain_l = mix.volume * math.cos(theta)
+        mix.gain_r = mix.volume * math.sin(theta)
+
+    async def _broadcast_state(self):
+        now = time.time()
+        if now - self._last_broadcast < 0.03:
+            return
+        self._last_broadcast = now
+        payload = {
+            "type": "snapshot",
+            "mixes": {name: asdict(m) for name, m in self.state.mixes.items()},
+        }
+        await self.bus.publish(payload)
+
+    # --- Public mutators -------------------------------------------------
+    async def set_join(self, mix: str, joined: bool):
+        m = self.state.mixes[mix]
+        m.joined = joined
+        if joined:
+            self._apply_stereo_join(m)
+        await self._broadcast_state()
+
+    async def set_volume(self, mix: str, value: float):
+        m = self.state.mixes[mix]
+        m.volume = max(0.0, min(1.0, value))
+        if m.joined:
+            self._apply_stereo_join(m)
+        await self._broadcast_state()
+
+    async def set_pan(self, mix: str, value: float):
+        m = self.state.mixes[mix]
+        m.pan = max(-1.0, min(1.0, value))
+        if m.joined:
+            self._apply_stereo_join(m)
+        await self._broadcast_state()
+
+    async def set_lr(self, mix: str, l: Optional[float] = None, r: Optional[float] = None):
+        m = self.state.mixes[mix]
+        if l is not None:
+            m.gain_l = max(0.0, min(1.0, l))
+        if r is not None:
+            m.gain_r = max(0.0, min(1.0, r))
+        await self._broadcast_state()
+
+    # --- Fake meters task ------------------------------------------------
+    async def meters_task(self):
+        t = 0.0
+        while not self._stop.is_set():
+            t += 0.03
+            for mix in self.state.mixes.values():
+                base = 0.2 + 0.2 * (math.sin(t * 1.3) + 1) / 2
+                wiggle = 0.1 * (math.sin(t * 7.1) + 1) / 2
+                left_source = mix.gain_l if mix.joined else mix.gain_l or mix.volume
+                right_source = mix.gain_r if mix.joined else mix.gain_r or mix.volume
+                mix.level_l = max(0.0, min(1.0, left_source * (base + wiggle)))
+                mix.level_r = max(0.0, min(1.0, right_source * (base + wiggle * 0.8)))
+            await self._broadcast_state()
+            await asyncio.sleep(0.03)
+
+    async def run(self):
+        await self._broadcast_state()
+        await self._stop.wait()
+
+    async def shutdown(self):
+        self._stop.set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "fastapi>=0.115",
   "uvicorn>=0.30",
   "pydantic>=2.8",
+  "websockets>=12",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "scarlett-mixer"
+version = "0.1.0"
+description = "Qt/QML mixer with web remote (prototype)"
+requires-python = ">=3.10"
+dependencies = [
+  "PySide6>=6.7",
+  "qasync>=0.27.1",
+  "fastapi>=0.115",
+  "uvicorn>=0.30",
+  "pydantic>=2.8",
+]
+
+[project.scripts]
+scarlett-mixer = "app:main_entry"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -19,7 +19,7 @@ dependencies = [
 py-modules = ["app", "backend", "server"]
 
 [tool.setuptools.package-data]
-"" = [
+"*" = [
   "ui/*.qml",
   "web/*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "scarlett-mixer"
 version = "0.1.0"
@@ -9,6 +13,15 @@ dependencies = [
   "fastapi>=0.115",
   "uvicorn>=0.30",
   "pydantic>=2.8",
+]
+
+[tool.setuptools]
+py-modules = ["app", "backend", "server"]
+
+[tool.setuptools.package-data]
+"" = [
+  "ui/*.qml",
+  "web/*",
 ]
 
 [project.scripts]

--- a/server.py
+++ b/server.py
@@ -1,9 +1,12 @@
+from pathlib import Path
+from typing import Optional
+
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 
-def build_api(backend) -> FastAPI:
+def build_api(backend, static_dir: Optional[Path] = None) -> FastAPI:
     app = FastAPI()
 
     class SetGain(BaseModel):
@@ -18,7 +21,8 @@ def build_api(backend) -> FastAPI:
         mix: str
         joined: bool
 
-    app.mount("/", StaticFiles(directory="web", html=True), name="web")
+    assets = static_dir or Path(__file__).resolve().parent / "web"
+    app.mount("/", StaticFiles(directory=str(assets), html=True), name="web")
 
     @app.websocket("/ws")
     async def ws_endpoint(ws: WebSocket):

--- a/server.py
+++ b/server.py
@@ -21,9 +21,6 @@ def build_api(backend, static_dir: Optional[Path] = None) -> FastAPI:
         mix: str
         joined: bool
 
-    assets = static_dir or Path(__file__).resolve().parent / "web"
-    app.mount("/", StaticFiles(directory=str(assets), html=True), name="web")
-
     @app.websocket("/ws")
     async def ws_endpoint(ws: WebSocket):
         await ws.accept()
@@ -64,5 +61,8 @@ def build_api(backend, static_dir: Optional[Path] = None) -> FastAPI:
             pass
         finally:
             backend.bus.unsubscribe(push)
+
+    assets = static_dir or Path(__file__).resolve().parent / "web"
+    app.mount("/", StaticFiles(directory=str(assets), html=True), name="web")
 
     return app

--- a/server.py
+++ b/server.py
@@ -1,0 +1,64 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+
+def build_api(backend) -> FastAPI:
+    app = FastAPI()
+
+    class SetGain(BaseModel):
+        mix: str
+        value: float
+
+    class SetPan(BaseModel):
+        mix: str
+        value: float
+
+    class SetJoin(BaseModel):
+        mix: str
+        joined: bool
+
+    app.mount("/", StaticFiles(directory="web", html=True), name="web")
+
+    @app.websocket("/ws")
+    async def ws_endpoint(ws: WebSocket):
+        await ws.accept()
+
+        async def push(msg: dict):
+            try:
+                await ws.send_json(msg)
+            except Exception:
+                pass
+
+        backend.bus.subscribe(push)
+        try:
+            await push(
+                {
+                    "type": "snapshot",
+                    "mixes": {k: vars(v) for k, v in backend.state.mixes.items()},
+                }
+            )
+            while True:
+                msg = await ws.receive_json()
+                op = msg.get("op")
+                data = msg.get("data") or {}
+                if op == "set_gain":
+                    payload = SetGain(**data)
+                    await backend.set_volume(payload.mix, payload.value)
+                elif op == "set_pan":
+                    payload = SetPan(**data)
+                    await backend.set_pan(payload.mix, payload.value)
+                elif op == "set_join":
+                    payload = SetJoin(**data)
+                    await backend.set_join(payload.mix, payload.joined)
+                elif op == "set_lr":
+                    mix = data.get("mix")
+                    l = data.get("l")
+                    r = data.get("r")
+                    await backend.set_lr(mix, l, r)
+        except WebSocketDisconnect:
+            pass
+        finally:
+            backend.bus.unsubscribe(push)
+
+    return app

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -21,20 +21,30 @@ ApplicationWindow {
             if (name !== "A")
                 return
 
-            joinSwitch.syncing = true
-            joinSwitch.checked = data.joined
+            if (joinSwitch.checked !== data.joined) {
+                joinSwitch.syncing = true
+                joinSwitch.checked = data.joined
+            }
 
-            volumeSlider.syncing = true
-            volumeSlider.value = data.volume
+            if (Math.abs(volumeSlider.value - data.volume) > 0.0005) {
+                volumeSlider.syncing = true
+                volumeSlider.value = data.volume
+            }
 
-            panDial.syncing = true
-            panDial.value = data.pan
+            if (Math.abs(panDial.value - data.pan) > 0.0005) {
+                panDial.syncing = true
+                panDial.value = data.pan
+            }
 
-            leftSlider.syncing = true
-            leftSlider.value = data.gain_l
+            if (Math.abs(leftSlider.value - data.gain_l) > 0.0005) {
+                leftSlider.syncing = true
+                leftSlider.value = data.gain_l
+            }
 
-            rightSlider.syncing = true
-            rightSlider.value = data.gain_r
+            if (Math.abs(rightSlider.value - data.gain_r) > 0.0005) {
+                rightSlider.syncing = true
+                rightSlider.value = data.gain_r
+            }
 
             root.mixALevelL = data.level_l || 0
             root.mixALevelR = data.level_r || 0

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -24,6 +24,7 @@ ApplicationWindow {
             if (joinSwitch.checked !== data.joined) {
                 joinSwitch.syncing = true
                 joinSwitch.checked = data.joined
+                Qt.callLater(function() { joinSwitch.syncing = false })
             }
 
             if (Math.abs(volumeSlider.value - data.volume) > 0.0005) {

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -1,0 +1,144 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Controls.Material 2.15
+import QtQuick.Layouts 1.15
+
+ApplicationWindow {
+    id: root
+    width: 960
+    height: 600
+    visible: true
+    title: "Scarlett Mixer (Prototype)"
+
+    Material.theme: Material.Dark
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 12
+        padding: 12
+
+        Label {
+            text: "Mix A"
+            font.pixelSize: 20
+        }
+
+        RowLayout {
+            spacing: 24
+
+            Switch {
+                id: joinSwitch
+                text: "Join L/R"
+                checked: true
+                onToggled: bridge.setJoin("A", checked)
+            }
+
+            ColumnLayout {
+                visible: joinSwitch.checked
+
+                Label { text: "Volume" }
+
+                Slider {
+                    id: volumeSlider
+                    from: 0
+                    to: 1
+                    value: 0.75
+                    stepSize: 0.01
+                    onMoved: bridge.setVolume("A", value)
+                }
+            }
+
+            ColumnLayout {
+                visible: joinSwitch.checked
+
+                Label { text: "Pan" }
+
+                Dial {
+                    id: panDial
+                    from: -1
+                    to: 1
+                    value: 0
+                    stepSize: 0.01
+                    onMoved: bridge.setPan("A", value)
+                }
+            }
+
+            ColumnLayout {
+                visible: !joinSwitch.checked
+
+                Label { text: "Left" }
+
+                Slider {
+                    id: leftSlider
+                    from: 0
+                    to: 1
+                    value: 0.75
+                    stepSize: 0.01
+                    onMoved: bridge.setLR("A", value, -1)
+                }
+            }
+
+            ColumnLayout {
+                visible: !joinSwitch.checked
+
+                Label { text: "Right" }
+
+                Slider {
+                    id: rightSlider
+                    from: 0
+                    to: 1
+                    value: 0.75
+                    stepSize: 0.01
+                    onMoved: bridge.setLR("A", -1, value)
+                }
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            height: 100
+            radius: 8
+            border.width: 1
+            opacity: 0.9
+
+            RowLayout {
+                anchors.fill: parent
+                spacing: 8
+
+                Repeater {
+                    model: 10
+
+                    Rectangle {
+                        Layout.fillHeight: true
+                        width: 14
+                        color: "#202020"
+                        radius: 4
+                        border.width: 1
+
+                        property real level: Math.abs(Math.sin((Date.now() / 1000 + index) * 0.7))
+
+                        Rectangle {
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.bottom: parent.bottom
+                            height: parent.height * parent.level
+                            color: level > 0.8 ? "#ff4d4d" : level > 0.6 ? "#ffaa00" : "#55ff55"
+                            radius: 4
+                        }
+                    }
+                }
+            }
+        }
+
+        Label {
+            text: "Open on phone: http://<your-ip>:8088/"
+            opacity: 0.7
+        }
+
+        Label {
+            text: "(Web UI can control Mix B in this prototype)"
+            opacity: 0.7
+        }
+
+        Item { Layout.fillHeight: true }
+    }
+}

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -14,8 +14,8 @@ ApplicationWindow {
 
     ColumnLayout {
         anchors.fill: parent
+        anchors.margins: 12
         spacing: 12
-        padding: 12
 
         Label {
             text: "Mix A"

--- a/web/app.js
+++ b/web/app.js
@@ -24,7 +24,7 @@ let lastMeter = 0;
 ws.onmessage = (event) => {
   const msg = JSON.parse(event.data);
   if (msg.type === 'snapshot') {
-    const mix = msg.mixes['B'];
+    const mix = msg.mixes['A'];
     if (!mix) return;
 
     join.checked = mix.joined;
@@ -50,10 +50,10 @@ ws.onmessage = (event) => {
 };
 
 join.addEventListener('change', () => {
-  send('set_join', { mix: 'B', joined: join.checked });
+  send('set_join', { mix: 'A', joined: join.checked });
 });
 
-vol.addEventListener('input', () => send('set_gain', { mix: 'B', value: parseFloat(vol.value) }));
-pan.addEventListener('input', () => send('set_pan', { mix: 'B', value: parseFloat(pan.value) }));
-l.addEventListener('input', () => send('set_lr', { mix: 'B', l: parseFloat(l.value) }));
-r.addEventListener('input', () => send('set_lr', { mix: 'B', r: parseFloat(r.value) }));
+vol.addEventListener('input', () => send('set_gain', { mix: 'A', value: parseFloat(vol.value) }));
+pan.addEventListener('input', () => send('set_pan', { mix: 'A', value: parseFloat(pan.value) }));
+l.addEventListener('input', () => send('set_lr', { mix: 'A', l: parseFloat(l.value) }));
+r.addEventListener('input', () => send('set_lr', { mix: 'A', r: parseFloat(r.value) }));

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,59 @@
+const ws = new WebSocket((location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/ws');
+const statusEl = document.getElementById('status');
+const join = document.getElementById('join');
+const vol = document.getElementById('vol');
+const pan = document.getElementById('pan');
+const ml = document.getElementById('ml');
+const mr = document.getElementById('mr');
+const joinedRow = document.getElementById('joinedRow');
+const splitRow = document.getElementById('splitRow');
+const l = document.getElementById('l');
+const r = document.getElementById('r');
+
+function send(op, data) {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify({ op, data }));
+  }
+}
+
+ws.onopen = () => (statusEl.textContent = 'connected');
+ws.onclose = () => (statusEl.textContent = 'disconnected');
+ws.onerror = () => (statusEl.textContent = 'error');
+
+let lastMeter = 0;
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.type === 'snapshot') {
+    const mix = msg.mixes['B'];
+    if (!mix) return;
+
+    join.checked = mix.joined;
+    if (mix.joined) {
+      joinedRow.style.display = 'flex';
+      splitRow.style.display = 'none';
+      vol.value = mix.volume;
+      pan.value = mix.pan;
+    } else {
+      joinedRow.style.display = 'none';
+      splitRow.style.display = 'flex';
+      l.value = mix.gain_l;
+      r.value = mix.gain_r;
+    }
+
+    const now = performance.now();
+    if (now - lastMeter > 33) {
+      ml.style.height = Math.round(100 * (mix.level_l || 0)) + '%';
+      mr.style.height = Math.round(100 * (mix.level_r || 0)) + '%';
+      lastMeter = now;
+    }
+  }
+};
+
+join.addEventListener('change', () => {
+  send('set_join', { mix: 'B', joined: join.checked });
+});
+
+vol.addEventListener('input', () => send('set_gain', { mix: 'B', value: parseFloat(vol.value) }));
+pan.addEventListener('input', () => send('set_pan', { mix: 'B', value: parseFloat(pan.value) }));
+l.addEventListener('input', () => send('set_lr', { mix: 'B', l: parseFloat(l.value) }));
+r.addEventListener('input', () => send('set_lr', { mix: 'B', r: parseFloat(r.value) }));

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Scarlett Mix – Remote</title>
+    <style>
+      body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu; margin:16px; background:#101216; color:#e8e8e8}
+      .card{background:#181b22; border:1px solid #2a2f3a; border-radius:12px; padding:16px; max-width:520px}
+      .row{display:flex; gap:12px; align-items:center}
+      .meter{width:12px; height:120px; border-radius:6px; background:#222; border:1px solid #333; position:relative}
+      .bar{position:absolute; bottom:0; left:0; right:0; background:#58d36f; border-radius:6px}
+      input[type=range]{width:100%}
+      .muted{opacity:0.5}
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h2>Mix B</h2>
+      <label>Join L/R <input id="join" type="checkbox" checked></label>
+      <div class="row" id="joinedRow">
+        <div style="flex:1">
+          <div>Volume</div>
+          <input id="vol" type="range" min="0" max="1" step="0.01" value="0.6" />
+        </div>
+        <div style="width:140px">
+          <div>Pan</div>
+          <input id="pan" type="range" min="-1" max="1" step="0.01" value="0" />
+        </div>
+        <div class="meter"><div id="ml" class="bar" style="height:20%"></div></div>
+        <div class="meter"><div id="mr" class="bar" style="height:25%"></div></div>
+      </div>
+      <div class="row" id="splitRow" style="display:none">
+        <div style="flex:1">
+          <div>Left</div>
+          <input id="l" type="range" min="0" max="1" step="0.01" value="0.5" />
+        </div>
+        <div style="flex:1">
+          <div>Right</div>
+          <input id="r" type="range" min="0" max="1" step="0.01" value="0.5" />
+        </div>
+      </div>
+      <div id="status" style="margin-top:8px; opacity:.7">connecting…</div>
+    </div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,7 @@
   </head>
   <body>
     <div class="card">
-      <h2>Mix B</h2>
+      <h2>Mix A</h2>
       <label>Join L/R <input id="join" type="checkbox" checked></label>
       <div class="row" id="joinedRow">
         <div style="flex:1">

--- a/web/index.html
+++ b/web/index.html
@@ -27,8 +27,6 @@
           <div>Pan</div>
           <input id="pan" type="range" min="-1" max="1" step="0.01" value="0" />
         </div>
-        <div class="meter"><div id="ml" class="bar" style="height:20%"></div></div>
-        <div class="meter"><div id="mr" class="bar" style="height:25%"></div></div>
       </div>
       <div class="row" id="splitRow" style="display:none">
         <div style="flex:1">
@@ -39,6 +37,10 @@
           <div>Right</div>
           <input id="r" type="range" min="0" max="1" step="0.01" value="0.5" />
         </div>
+      </div>
+      <div class="row" id="meterRow">
+        <div class="meter"><div id="ml" class="bar" style="height:20%"></div></div>
+        <div class="meter"><div id="mr" class="bar" style="height:25%"></div></div>
       </div>
       <div id="status" style="margin-top:8px; opacity:.7">connecting…</div>
     </div>


### PR DESCRIPTION
## Summary
- scaffold Qt/QML desktop mixer application with FastAPI WebSocket backend
- add backend state model, event bus, and uvicorn server integration
- include remote-friendly web UI and documentation for running the prototype

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d706717c7483309e6b47b9e5db7d75