### PR TITLE
Fix meters split mix gain handling

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -114,8 +114,8 @@ class Backend:
             for mix in self.state.mixes.values():
                 base = 0.2 + 0.2 * (math.sin(t * 1.3) + 1) / 2
                 wiggle = 0.1 * (math.sin(t * 7.1) + 1) / 2
-                left_source = mix.gain_l if mix.joined else mix.gain_l or mix.volume
-                right_source = mix.gain_r if mix.joined else mix.gain_r or mix.volume
+                left_source = mix.gain_l
+                right_source = mix.gain_r
                 mix.level_l = max(0.0, min(1.0, left_source * (base + wiggle)))
                 mix.level_r = max(0.0, min(1.0, right_source * (base + wiggle * 0.8)))
             await self._broadcast_state()


### PR DESCRIPTION
## Summary
- ensure the meters task always uses per-channel gains so split mixes respect zeroed sliders while keeping joined behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7196251848330a33c73b8c772423d